### PR TITLE
Update protoc version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="Bitkey Inc." \
       org.label-schema.vcs-ref=$VCS_REF
 
 ENV PROTOBUF_GIT_TAG="v1.2.0" \
-    PROTOC_VERSION="3.7.1"
+    PROTOC_VERSION="3.12.3"
 
 RUN go get github.com/golang/dep/cmd/dep \
     && go get google.golang.org/grpc \


### PR DESCRIPTION
# 目的・背景

- localのprotocのversion管理をしていないため、localのversionは最新でテストをしていた。（北村）
- 実環境で動作しているものも、このversionではない物が動いている。

# やったこと

- protoc の versionをあげる

# やっていないこと

- local 環境のversion管理
https://bit-key.atlassian.net/browse/BKP-1195